### PR TITLE
Safely handle empty ID values with `included` cache

### DIFF
--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -276,13 +276,12 @@ class Relationship(BaseRelationship):
 
     def _serialize_included(self, value):
         result = None
-        if self.__use_serialization_cache:
+        value_id = self._get_id(value)
+        if self.__use_serialization_cache and value_id is not None:
             try:
                 cache = self._serialization_cache
             except AttributeError:
                 cache = self._serialization_cache = {}
-            value_id = self._get_id(value)
-            assert value_id is not None
             cache_key = "%s.%s" % (value.__class__.__name__, value_id)
             result = cache.get(cache_key)
             if result is None:


### PR DESCRIPTION
In adopting #3, I've discovered there's a few valid use-cases for empty `id` fields, as this is something supported by marshmallow-jsonapi. Currently, we throw if a valid cache key cannot be found, whereas ideally we can treat these scenarios as a cache miss, since they're rare.

Serializers help enforce the JSON:API spec, but there's also situations where partial objects can be handy (e.g. in tests when serializing for a create request).

Pros to this change:
- behavior is closer to what's expected with the upstream package
- it's possible to serialize partial objects when needed

Cons:
- IDs are required by the spec for relationships, and this is more lax

I think it really boils down to whether or not we want this level of spec enforcement and if this is the place for that to happen. Something to consider!