### PR TITLE
Import from collections.abc for compatibility with Python 3.10

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 *********
 
+0.21.4 (2023-07-10)
+===================
+
+Other changes:
+
+* Import from `collections.abc` for compatibility with Python 3.10.
+
+
 0.21.3 (2020-03-20)
 ===================
 

--- a/marshmallow_jsonapi/__init__.py
+++ b/marshmallow_jsonapi/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from .schema import Schema, SchemaOpts
 
-__version__ = "0.21.3"
+__version__ = "0.21.4"
 __author__ = "Steven Loria"
 __license__ = "MIT"
 

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -2,7 +2,7 @@
 """Includes all the fields classes from `marshmallow.fields` as well as
 fields for serializing JSON API-formatted hyperlinks.
 """
-import collections
+import collections.abc
 import warnings
 
 from marshmallow import ValidationError, class_registry
@@ -341,13 +341,13 @@ class DocumentMeta(Field):
             self.data_key = _DOCUMENT_META_LOAD_FROM
 
     def _deserialize(self, value, attr, data, **kwargs):
-        if isinstance(value, collections.Mapping):
+        if isinstance(value, collections.abc.Mapping):
             return value
         else:
             self.fail("invalid")
 
     def _serialize(self, value, *args, **kwargs):
-        if isinstance(value, collections.Mapping):
+        if isinstance(value, collections.abc.Mapping):
             return super(DocumentMeta, self)._serialize(value, *args, **kwargs)
         else:
             self.fail("invalid")
@@ -381,13 +381,13 @@ class ResourceMeta(Field):
             self.data_key = _RESOURCE_META_LOAD_FROM
 
     def _deserialize(self, value, attr, data, **kwargs):
-        if isinstance(value, collections.Mapping):
+        if isinstance(value, collections.abc.Mapping):
             return value
         else:
             self.fail("invalid")
 
     def _serialize(self, value, *args, **kwargs):
-        if isinstance(value, collections.Mapping):
+        if isinstance(value, collections.abc.Mapping):
             return super(ResourceMeta, self)._serialize(value, *args, **kwargs)
         else:
             self.fail("invalid")


### PR DESCRIPTION
The current version of `marshmallow-jsonapi` is not compatible with Python 3.10. Since the upstream version that includes this change also requires `marshmallow` 3.x, patching it here until we are able to move to the latest version of `marshmallow`.