### PR TITLE
Fix serialization cache bypass in _serialize_included

### DIFF
--- a/marshmallow_jsonapi/__init__.py
+++ b/marshmallow_jsonapi/__init__.py
@@ -1,5 +1,5 @@
 from .schema import Schema, SchemaOpts
 
-__version__ = "0.24.0"
+__version__ = "0.24.1"
 __license__ = "MIT"
 __all__ = ("Schema", "SchemaOpts")

--- a/marshmallow_jsonapi/fields.py
+++ b/marshmallow_jsonapi/fields.py
@@ -295,10 +295,6 @@ class Relationship(BaseRelationship):
         else:
             result = self.schema.dump(value)
 
-        data = result
-
-        item = data["data"]
-        result = self.schema.dump(value)
         item = result["data"]
         self.root.included_data[(item["type"], item["id"])] = item
         for key, value in self.schema.included_data.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "marshmallow-jsonapi"
-version = "0.24.0"
+version = "0.24.1"
 description = "marshmallow-jsonapi provides a simple way to produce JSON API-compliant data in any Python web framework."
 authors = ["Your Name <you@example.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- The merge conflict resolution in d68f0ce kept both sides of a conflict in `_serialize_included()`, causing every included resource to be serialized fresh even when a cached result exists
- The cached result was computed but immediately overwritten by an unconditional `schema.dump()` call on the next line
- Removes the duplicate lines so the cache is actually used
- Bumps version to 0.24.1

## Before (broken)
```python
data = result                          # result from cache
item = data["data"]                    # extracts item from cache
result = self.schema.dump(value)       # DUMPS AGAIN unconditionally
item = result["data"]                  # OVERWRITES cached item
```

## After (fixed)
```python
item = result["data"]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)